### PR TITLE
bit-buffer

### DIFF
--- a/src/bit_buffer/bit_iter.rs
+++ b/src/bit_buffer/bit_iter.rs
@@ -10,7 +10,7 @@ pub struct BitIterator<'a> {
     incomplete_byte: Option<(u8, usize)>,
 }
 
-impl<'a> Iterator for BitIterator<'a> {
+impl Iterator for BitIterator<'_> {
     type Item = bool;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -48,7 +48,7 @@ impl<'a> Iterator for BitIterator<'a> {
     }
 }
 
-impl<'a> From<BitBuffer> for BitIterator<'a> {
+impl From<BitBuffer> for BitIterator<'_> {
     fn from(mut buffer: BitBuffer) -> Self {
         let mut full_bytes_iter = Box::new(buffer.get_complete_bytes());
         let current_idx = 0;

--- a/src/bit_buffer/bit_iter.rs
+++ b/src/bit_buffer/bit_iter.rs
@@ -1,0 +1,87 @@
+use crate::bit_buffer::BitBuffer;
+
+/// An iterator over bits. Can be derived from BitBuffer or a slice of bytes.
+pub struct BitIterator<'a> {
+    full_bytes_iter: Box<dyn Iterator<Item = u8> + 'a>,
+    current_byte: Option<u8>,
+    current_idx: usize,
+
+    // In case there is an incomplete byte, hold it and the number of bits in it:
+    incomplete_byte: Option<(u8, usize)>,
+}
+
+impl<'a> Iterator for BitIterator<'a> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // First try the current byte:
+        if let Some(byte) = self.current_byte.take() {
+            // Get current bit:
+            let bit = ((byte >> (7 - self.current_idx)) & 1) == 1;
+            self.current_idx += 1;
+
+            // Restore the current byte if not all bits are consumed, otherwise try to put a new one
+            // there:
+            if self.current_idx < 8 {
+                let _ = self.current_byte.insert(byte);
+            } else {
+                self.current_idx = 0;
+                self.current_byte = self.full_bytes_iter.next();
+            }
+            return Some(bit);
+        }
+
+        // Now try the incomplete byte:
+        if let Some((byte, num_bits)) = self.incomplete_byte.take() {
+            // Get current bit:
+            let bit = ((byte >> (7 - self.current_idx)) & 1) == 1;
+            self.current_idx += 1;
+
+            // Restore byte or remove incomplete one:
+            if self.current_idx < num_bits {
+                let _ = self.incomplete_byte.insert((byte, num_bits));
+            }
+            Some(bit)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> From<BitBuffer> for BitIterator<'a> {
+    fn from(mut buffer: BitBuffer) -> Self {
+        let mut full_bytes_iter = Box::new(buffer.get_complete_bytes());
+        let current_idx = 0;
+        let current_byte = full_bytes_iter.next();
+
+        let incomplete_byte = if buffer.current_idx > 0 {
+            Some((buffer.current_byte, buffer.current_idx))
+        } else {
+            None
+        };
+
+        Self {
+            full_bytes_iter,
+            current_idx,
+            current_byte,
+            incomplete_byte,
+        }
+    }
+}
+
+impl<'a, I: IntoIterator<Item = u8> + 'a> From<I> for BitIterator<'a> {
+    fn from(value: I) -> Self {
+        // There are only complete bytes here:
+        let mut full_bytes_iter = Box::new(value.into_iter());
+        let current_byte = full_bytes_iter.next();
+        let current_idx = 0;
+        let incomplete_byte = None;
+
+        Self {
+            full_bytes_iter,
+            current_byte,
+            current_idx,
+            incomplete_byte,
+        }
+    }
+}

--- a/src/bit_buffer/mod.rs
+++ b/src/bit_buffer/mod.rs
@@ -60,4 +60,12 @@ impl BitBuffer {
         self.current_byte = 0;
         self.current_idx = 0;
     }
+    
+    /// Extracts full bytes from the buffer and returns them as an iterator. If there aren't enough
+    /// bits in the buffer to form a single byte, the iterator will be empty.<br>
+    /// To remove ambiguity: **The bytes will not remain in the buffer after calling this
+    /// function**.
+    pub fn get_complete_bytes(&mut self) -> impl Iterator<Item = u8> {
+        std::mem::take(&mut self.full_bytes).into_iter()
+    }
 }

--- a/src/bit_buffer/mod.rs
+++ b/src/bit_buffer/mod.rs
@@ -1,0 +1,42 @@
+use std::collections::LinkedList;
+
+/// A buffer dedicated to bit storage
+#[derive(Debug)]
+pub struct BitBuffer {
+    full_bytes: LinkedList<u8>,
+    // Bits will be added to this byte, from its MSB to the LSB to preserve insertion order
+    current_byte: u8,
+    current_idx: usize,
+}
+
+impl BitBuffer {
+    /// Initializes an empty BitBuffer.
+    pub fn new() -> Self {
+        Self {
+            full_bytes: LinkedList::new(),
+            current_byte: 0,
+            current_idx: 0,
+        }
+    }
+
+    /// Inserts a single bit to the end of the buffer.
+    pub fn append(&mut self, bit: bool) {
+        if bit {
+            self.current_byte |= 1 << (7 - self.current_idx);
+        }
+        self.current_idx += 1;
+
+        // If the current byte is full, save it:
+        if self.current_idx >= 8 {
+            self.save_current_byte();
+        }
+    }
+
+    /// Saves the current byte into the `full_bytes` list, and resets both `current_idx` and
+    /// `current_idx`.
+    fn save_current_byte(&mut self) {
+        self.full_bytes.push_back(self.current_byte);
+        self.current_byte = 0;
+        self.current_idx = 0;
+    }
+}

--- a/src/bit_buffer/mod.rs
+++ b/src/bit_buffer/mod.rs
@@ -72,6 +72,23 @@ impl BitBuffer {
     pub fn get_complete_bytes(&mut self) -> impl Iterator<Item = u8> {
         std::mem::take(&mut self.full_bytes).into_iter()
     }
+    
+    /// If the number of bits in the buffer isn't divisible by 8, there will exist 'leftover' bits,
+    /// which cannot be turned into a byte without padding.
+    /// 
+    /// The function will return those leftover bits, padded with zeroes. Those zero bits will be
+    /// added to the right of the leftover bits (i.e: the least significant bit of the returned byte
+    /// is guaranteed to be a padding zero bit).
+    /// If no leftover bits exist, the function returns None.
+    /// 
+    /// Note that this operation does **not** remove those leftover bits from the buffer.
+    pub fn get_leftover_bits(&self) -> Option<u8> {
+        if self.current_idx > 0 {
+            Some(self.current_byte)
+        } else {
+            None
+        }
+    }
 }
 
 impl From<&[u8]> for BitBuffer {

--- a/src/bit_buffer/mod.rs
+++ b/src/bit_buffer/mod.rs
@@ -72,15 +72,20 @@ impl BitBuffer {
     pub fn get_complete_bytes(&mut self) -> impl Iterator<Item = u8> {
         std::mem::take(&mut self.full_bytes).into_iter()
     }
-    
+
+    /// Returns the number of **bits** in the buffer
+    pub fn len(&self) -> usize {
+        8 * self.full_bytes.len() + self.current_idx
+    }
+
     /// If the number of bits in the buffer isn't divisible by 8, there will exist 'leftover' bits,
     /// which cannot be turned into a byte without padding.
-    /// 
+    ///
     /// The function will return those leftover bits, padded with zeroes. Those zero bits will be
     /// added to the right of the leftover bits (i.e: the least significant bit of the returned byte
     /// is guaranteed to be a padding zero bit).
     /// If no leftover bits exist, the function returns None.
-    /// 
+    ///
     /// Note that this operation does **not** remove those leftover bits from the buffer.
     pub fn get_leftover_bits(&self) -> Option<u8> {
         if self.current_idx > 0 {

--- a/src/bit_buffer/mod.rs
+++ b/src/bit_buffer/mod.rs
@@ -72,3 +72,25 @@ impl BitBuffer {
         std::mem::take(&mut self.full_bytes).into_iter()
     }
 }
+
+impl From<&[u8]> for BitBuffer {
+    fn from(value: &[u8]) -> Self {
+        // Since whose are all full bytes, add them directly to the full_bytes list:
+        Self {
+            full_bytes: LinkedList::from_iter(value.iter().copied()),
+            current_byte: 0,
+            current_idx: 0,
+        }
+    }
+}
+
+impl From<Vec<u8>> for BitBuffer {
+    fn from(value: Vec<u8>) -> Self {
+        // Since whose are all full bytes, add them directly to the full_bytes list:
+        Self {
+            full_bytes: LinkedList::from_iter(value),
+            current_byte: 0,
+            current_idx: 0,
+        }
+    }
+}

--- a/src/bit_buffer/mod.rs
+++ b/src/bit_buffer/mod.rs
@@ -1,3 +1,4 @@
+mod bit_iter;
 #[cfg(test)]
 mod unit_tests;
 

--- a/src/bit_buffer/mod.rs
+++ b/src/bit_buffer/mod.rs
@@ -32,6 +32,27 @@ impl BitBuffer {
         }
     }
 
+    /// Inserts a single bit to the end of the buffer multiple times. This method is more efficient
+    /// than calling `append` in a loop.
+    ///
+    /// Note that specifying 0 repetitions is allowed, and won't change the buffer.
+    pub fn append_repeated(&mut self, bit: bool, mut repetitions: usize) {
+        let bit_repeated = if bit { u8::MAX } else { 0 };
+
+        while repetitions >= 8 {
+            // Add to the current byte, then save it:
+            self.current_byte |= bit_repeated >> self.current_idx;
+            repetitions -= 8 - self.current_idx;
+            self.save_current_byte();
+        }
+
+        // Insert leftover bits to current_byte if needed, update current_idx:
+        if repetitions > 0 && bit {
+            self.current_byte |= u8::MAX << (8 - repetitions);
+        }
+        self.current_idx = repetitions;
+    }
+
     /// Saves the current byte into the `full_bytes` list, and resets both `current_idx` and
     /// `current_idx`.
     fn save_current_byte(&mut self) {

--- a/src/bit_buffer/mod.rs
+++ b/src/bit_buffer/mod.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod unit_tests;
+
 use std::collections::LinkedList;
 
 /// A buffer dedicated to bit storage
@@ -60,7 +63,7 @@ impl BitBuffer {
         self.current_byte = 0;
         self.current_idx = 0;
     }
-    
+
     /// Extracts full bytes from the buffer and returns them as an iterator. If there aren't enough
     /// bits in the buffer to form a single byte, the iterator will be empty.<br>
     /// To remove ambiguity: **The bytes will not remain in the buffer after calling this

--- a/src/bit_buffer/unit_tests.rs
+++ b/src/bit_buffer/unit_tests.rs
@@ -224,3 +224,78 @@ fn test_full_bytes_multiple_bytes_with_remainder() {
     assert_eq!(buffer.current_byte, 0);
     assert_eq!(buffer.current_idx, 3);
 }
+
+#[test]
+fn test_from_slice() {
+    // Test converting a slice into a BitBuffer
+    let data: &[u8] = &[0b10101010, 0b11001100, 0b11110000];
+    let mut buffer: BitBuffer = data.into();
+
+    // The buffer should have exactly 3 bytes
+    assert_eq!(buffer.full_bytes.len(), 3);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+
+    // Check the contents of the bytes in the buffer
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(bytes, vec![0b10101010, 0b11001100, 0b11110000]);
+    assert!(buffer.full_bytes.is_empty());
+}
+
+#[test]
+fn test_from_vec() {
+    // Test converting a Vec<u8> into a BitBuffer
+    let data: Vec<u8> = vec![0b10101010, 0b11001100, 0b11110000];
+    let mut buffer: BitBuffer = data.into();
+
+    // The buffer should have exactly 3 bytes
+    assert_eq!(buffer.full_bytes.len(), 3);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+
+    // Check the contents of the bytes in the buffer
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(bytes, vec![0b10101010, 0b11001100, 0b11110000]);
+    assert!(buffer.full_bytes.is_empty());
+}
+
+#[test]
+fn test_from_empty_slice() {
+    // Test converting an empty slice into a BitBuffer
+    let data: &[u8] = &[];
+    let buffer: BitBuffer = data.into();
+
+    // The buffer should have no bytes
+    assert_eq!(buffer.full_bytes.len(), 0);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+}
+
+#[test]
+fn test_from_empty_vec() {
+    // Test converting an empty Vec<u8> into a BitBuffer
+    let data: Vec<u8> = Vec::new();
+    let buffer: BitBuffer = data.into();
+
+    // The buffer should have no bytes
+    assert_eq!(buffer.full_bytes.len(), 0);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+}
+
+#[test]
+fn test_from_single_byte() {
+    // Test converting a single byte slice into a BitBuffer
+    let data: &[u8] = &[0b10101010];
+    let mut buffer: BitBuffer = data.into();
+
+    // The buffer should have exactly 1 byte
+    assert_eq!(buffer.full_bytes.len(), 1);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+
+    // Check the contents of the bytes in the buffer
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(bytes, vec![0b10101010]);
+    assert!(buffer.full_bytes.is_empty());
+}

--- a/src/bit_buffer/unit_tests.rs
+++ b/src/bit_buffer/unit_tests.rs
@@ -1,0 +1,226 @@
+use crate::bit_buffer::BitBuffer;
+
+#[test]
+fn empty_upon_initializing() {
+    let buffer = BitBuffer::new();
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+    assert!(buffer.full_bytes.is_empty())
+}
+
+#[test]
+fn test_less_than_byte_appends() {
+    let mut buffer = BitBuffer::new();
+
+    buffer.append(false);
+    assert_eq!(buffer.current_byte, 0u8);
+    assert_eq!(buffer.current_idx, 1);
+    assert!(buffer.full_bytes.is_empty());
+
+    buffer.append(true);
+    assert_eq!(buffer.current_byte, 0b01000000u8);
+    assert_eq!(buffer.current_idx, 2);
+    assert!(buffer.full_bytes.is_empty());
+}
+
+#[test]
+fn test_exactly_one_byte_appends() {
+    let mut buffer = BitBuffer::new();
+    buffer.append(true);
+    buffer.append(false);
+    buffer.append(true);
+    buffer.append(true);
+    buffer.append(false);
+    buffer.append(true);
+    buffer.append(true);
+    buffer.append(true);
+
+    assert_eq!(buffer.full_bytes.len(), 1);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+
+    let first_byte = buffer.full_bytes.front().unwrap();
+    assert_eq!(first_byte, &0b10110111u8);
+}
+
+#[test]
+fn test_over_one_byte_appends() {
+    let mut buffer = BitBuffer::new();
+    buffer.append(true);
+    buffer.append(false);
+    buffer.append(true);
+    buffer.append(true);
+    buffer.append(false);
+    buffer.append(true);
+    buffer.append(true);
+    buffer.append(true);
+
+    buffer.append(false);
+    buffer.append(true);
+
+    assert_eq!(buffer.full_bytes.len(), 1);
+    assert_eq!(buffer.current_byte, 0b01000000);
+    assert_eq!(buffer.current_idx, 2);
+
+    let first_byte = buffer.full_bytes.front().unwrap();
+    assert_eq!(first_byte, &0b10110111u8);
+}
+
+#[test]
+fn test_less_than_byte_appends_repeated() {
+    let mut buffer = BitBuffer::new();
+    buffer.append_repeated(true, 5);
+    assert_eq!(buffer.current_byte, 0b11111000u8);
+    assert_eq!(buffer.current_idx, 5);
+    assert!(buffer.full_bytes.is_empty());
+
+    buffer = BitBuffer::new();
+    buffer.append_repeated(false, 4);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 4);
+    assert!(buffer.full_bytes.is_empty());
+}
+
+#[test]
+fn test_exactly_one_byte_appends_repeated() {
+    let mut buffer = BitBuffer::new();
+    buffer.append_repeated(true, 8);
+
+    assert_eq!(buffer.full_bytes.len(), 1);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+    let byte = buffer.full_bytes.front().unwrap();
+    assert_eq!(byte, &u8::MAX);
+
+    buffer = BitBuffer::new();
+    buffer.append_repeated(false, 8);
+
+    assert_eq!(buffer.full_bytes.len(), 1);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+    let byte = buffer.full_bytes.front().unwrap();
+    assert_eq!(byte, &0);
+}
+
+#[test]
+fn test_over_one_byte_appends_repeated() {
+    let mut buffer = BitBuffer::new();
+    buffer.append_repeated(true, 18);
+
+    assert_eq!(buffer.full_bytes.len(), 2);
+    assert_eq!(buffer.current_byte, 0b11000000u8);
+    assert_eq!(buffer.current_idx, 2);
+
+    let (front, back) = (
+        buffer.full_bytes.front().unwrap(),
+        buffer.full_bytes.back().unwrap(),
+    );
+    assert_eq!(front, &u8::MAX);
+    assert_eq!(back, &u8::MAX);
+
+    buffer = BitBuffer::new();
+    buffer.append_repeated(false, 19);
+
+    assert_eq!(buffer.full_bytes.len(), 2);
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 3);
+
+    let (front, back) = (
+        buffer.full_bytes.front().unwrap(),
+        buffer.full_bytes.back().unwrap(),
+    );
+    assert_eq!(front, &0);
+    assert_eq!(back, &0);
+}
+
+#[test]
+fn test_full_bytes_new_buffer() {
+    let mut buffer = BitBuffer::new();
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(bytes, Vec::new());
+    assert!(buffer.full_bytes.is_empty());
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+}
+
+#[test]
+fn test_full_bytes_not_enough_bits() {
+    let mut buffer = BitBuffer::new();
+    buffer.append_repeated(true, 6);
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(bytes, Vec::new());
+    assert!(buffer.full_bytes.is_empty());
+    assert_eq!(buffer.current_byte, 0b11111100);
+    assert_eq!(buffer.current_idx, 6);
+
+    buffer = BitBuffer::new();
+    buffer.append_repeated(false, 7);
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(bytes, Vec::new());
+    assert!(buffer.full_bytes.is_empty());
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 7);
+}
+
+#[test]
+fn test_full_bytes_exactly_one_byte() {
+    let mut buffer = BitBuffer::new();
+    buffer.append_repeated(true, 8);
+
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(vec![u8::MAX], bytes);
+    assert!(buffer.full_bytes.is_empty());
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+
+    buffer = BitBuffer::new();
+    buffer.append_repeated(false, 8);
+
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(vec![0], bytes);
+    assert!(buffer.full_bytes.is_empty());
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+}
+
+#[test]
+fn test_full_bytes_multiple_bytes_no_remainder() {
+    let mut buffer = BitBuffer::new();
+    buffer.append_repeated(true, 16);
+
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(vec![u8::MAX, u8::MAX], bytes);
+    assert!(buffer.full_bytes.is_empty());
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+
+    buffer = BitBuffer::new();
+    buffer.append_repeated(false, 24);
+
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(vec![0, 0, 0], bytes);
+    assert!(buffer.full_bytes.is_empty());
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 0);
+}
+
+#[test]
+fn test_full_bytes_multiple_bytes_with_remainder() {
+    let mut buffer = BitBuffer::new();
+    buffer.append_repeated(true, 20);
+
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(vec![u8::MAX, u8::MAX], bytes);
+    assert!(buffer.full_bytes.is_empty());
+    assert_eq!(buffer.current_byte, 0b11110000);
+    assert_eq!(buffer.current_idx, 4);
+
+    buffer = BitBuffer::new();
+    buffer.append_repeated(false, 27);
+
+    let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
+    assert_eq!(vec![0, 0, 0], bytes);
+    assert!(buffer.full_bytes.is_empty());
+    assert_eq!(buffer.current_byte, 0);
+    assert_eq!(buffer.current_idx, 3);
+}

--- a/src/bit_buffer/unit_tests.rs
+++ b/src/bit_buffer/unit_tests.rs
@@ -302,6 +302,50 @@ fn test_from_single_byte() {
 }
 
 #[test]
+fn test_leftover_empty() {
+    let buffer = BitBuffer::new();
+    assert!(buffer.get_leftover_bits().is_none());
+}
+
+#[test]
+fn test_leftover_less_than_byte() {
+    let mut buffer = BitBuffer::new();
+    buffer.append(true);
+    buffer.append(false);
+    buffer.append(true);
+    
+    let leftover = buffer.get_leftover_bits();
+    assert!(leftover.is_some());
+    assert_eq!(leftover.unwrap(), 0b10100000);
+}
+
+#[test]
+fn test_leftover_exactly_one_byte() {
+    let buffer = BitBuffer::from(vec![0b10011010u8]);
+    
+    let leftover = buffer.get_leftover_bits();
+    assert!(leftover.is_none());
+}
+
+#[test]
+fn test_leftover_byte_with_remainder() {
+    let mut buffer = BitBuffer::from(vec![0b10011010u8]);
+    buffer.append(false);
+    
+    let leftover = buffer.get_leftover_bits();
+    assert!(leftover.is_some());
+    assert_eq!(leftover.unwrap(), 0);
+}
+
+#[test] 
+fn test_leftover_multiple_bytes_no_remainder() {
+    let buffer = BitBuffer::from(vec![15, 120u8, 11, 33]);
+
+    let leftover = buffer.get_leftover_bits();
+    assert!(leftover.is_none());
+}
+
+#[test]
 fn test_bit_iterator_empty() {
     let buffer = BitBuffer::new();
     let bit_iterator: BitIterator = buffer.into();

--- a/src/bit_buffer/unit_tests.rs
+++ b/src/bit_buffer/unit_tests.rs
@@ -135,6 +135,25 @@ fn test_over_one_byte_appends_repeated() {
 }
 
 #[test]
+fn test_len_empty() {
+    let buffer = BitBuffer::new();
+    assert_eq!(buffer.len(), 0);
+}
+
+#[test]
+fn test_len_less_than_byte() {
+    let mut buffer = BitBuffer::new();
+    buffer.append_repeated(false, 5);
+    assert_eq!(buffer.len(), 5);
+}
+
+#[test]
+fn test_len_multiple_bytes() {
+    let buffer = BitBuffer::from(vec![100, 11, 23, 45, 68, 19]);
+    assert_eq!(buffer.len(), 8 * 6);
+}
+
+#[test]
 fn test_full_bytes_new_buffer() {
     let mut buffer = BitBuffer::new();
     let bytes: Vec<u8> = buffer.get_complete_bytes().collect();
@@ -313,7 +332,7 @@ fn test_leftover_less_than_byte() {
     buffer.append(true);
     buffer.append(false);
     buffer.append(true);
-    
+
     let leftover = buffer.get_leftover_bits();
     assert!(leftover.is_some());
     assert_eq!(leftover.unwrap(), 0b10100000);
@@ -322,7 +341,7 @@ fn test_leftover_less_than_byte() {
 #[test]
 fn test_leftover_exactly_one_byte() {
     let buffer = BitBuffer::from(vec![0b10011010u8]);
-    
+
     let leftover = buffer.get_leftover_bits();
     assert!(leftover.is_none());
 }
@@ -331,13 +350,13 @@ fn test_leftover_exactly_one_byte() {
 fn test_leftover_byte_with_remainder() {
     let mut buffer = BitBuffer::from(vec![0b10011010u8]);
     buffer.append(false);
-    
+
     let leftover = buffer.get_leftover_bits();
     assert!(leftover.is_some());
     assert_eq!(leftover.unwrap(), 0);
 }
 
-#[test] 
+#[test]
 fn test_leftover_multiple_bytes_no_remainder() {
     let buffer = BitBuffer::from(vec![15, 120u8, 11, 33]);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@
 
 #![allow(dead_code)]
 
+mod bit_buffer;
 mod number_types;
 
 fn main() {


### PR DESCRIPTION
A module with two important structs:
1) BitBuffer
2) BitIterator

Both structs have unit tests dedicated to them, which they passed.

## BitBuffer
A useful struct for storing individual bits, and then converting them to bytes.
Will be useful later since arithmetic coding outputs bits at every step, not necessarily full bytes.
## BitIterator
An iterator over individual bits, can be constructed using a BitBuffer or anything that can turn into an iterator of bytes.
Will be useful in the decompression step when we'll need to read bits one at a time.