### PR TITLE
frequency-tables

### DIFF
--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+pub mod static_table;
 mod symbol;
 
 pub use self::symbol::Symbol;

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -40,7 +40,7 @@ pub trait FrequencyTable {
 
     /// Given a cumulative frequency value, return the index whose assigned CFI contains the value.
     /// If such CFI is not found, None is returned.
-    fn get_symbol(&self, cumulative_frequency: Frequency) -> Option<usize>;
+    fn get_index(&self, cumulative_frequency: Frequency) -> Option<usize>;
 
     /// Returns the total cumulative number of frequencies saved in the table.
     fn get_total(&self) -> Frequency;

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -18,7 +18,6 @@
 pub mod static_table;
 mod symbol;
 
-pub use self::symbol::Symbol;
 use crate::number_types::{ConstrainedNum, FREQUENCY_BITS};
 
 /// Number type for all frequencies, used to limit a frequency's bits
@@ -32,15 +31,17 @@ pub struct Cfi {
     pub total: Frequency,
 }
 
-/// The necessary functions any frequency table must implement
+/// A frequency table is anything that assigns Cumulative-Frequency-Intervals to indices. The
+/// following trait defines its required functions.
 pub trait FrequencyTable {
-    /// Returns the CFI assigned to the given symbol, or None if such CFI is empty (start == end).
-    fn get_cfi(&self, symbol: &Symbol) -> Option<Cfi>;
+    /// Returns the CFI assigned to the given index, or None if such CFI is empty (start == end) or
+    /// the index is out of the table's bounds.
+    fn get_cfi(&self, index: usize) -> Option<Cfi>;
 
-    /// Given a cumulative frequency value, return the symbol whose CFI contains the value.
+    /// Given a cumulative frequency value, return the index whose assigned CFI contains the value.
     /// If such CFI is not found, None is returned.
-    fn get_symbol(&self, cumulative_frequency: Frequency) -> Option<Symbol>;
+    fn get_symbol(&self, cumulative_frequency: Frequency) -> Option<usize>;
 
-    /// Returns the total number of frequencies saved in the table.
+    /// Returns the total cumulative number of frequencies saved in the table.
     fn get_total(&self) -> Frequency;
 }

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -15,64 +15,12 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+mod symbol;
+
 use crate::number_types::{ConstrainedNum, FREQUENCY_BITS};
-use std::fmt::{Display, Formatter};
 
 /// Number type for all frequencies, used to limit a frequency's bits
 pub type Frequency = ConstrainedNum<FREQUENCY_BITS>;
-
-/// The number of unique symbols (256 byte values + 1 EOF + 1 ESCAPE)
-pub const UNIQUE_SYMBOLS_AMOUNT: usize = 258;
-
-/// A symbol in the compression/decompression process, its possible values contain all byte values
-/// plus additional metadata values
-#[derive(Copy, Clone, Debug)]
-pub enum Symbol {
-    /// A byte value
-    Byte(u8),
-    /// An End-Of-File value
-    Eof,
-    /// An 'escape' value
-    Esc,
-}
-
-impl Symbol {
-    pub fn is_escape(&self) -> bool {
-        matches!(self, Symbol::Esc)
-    }
-
-    /// Maps a symbol to an index. It is guaranteed that if two symbols are not the same, they will
-    /// never receive the same index, and that the returned index is within the interval
-    /// `[0, UNIQUE_SYMBOLS_AMOUNT)`.
-    pub const fn get_index(&self) -> usize {
-        match self {
-            Symbol::Byte(byte) => *byte as usize,
-            Symbol::Eof => 256,
-            Symbol::Esc => 257,
-        }
-    }
-
-    /// Constructs the original symbol from its assigned index. If the given index isn't mapped to
-    /// any symbol, None is returned.
-    pub const fn from_index(index: usize) -> Option<Self> {
-        match index {
-            byte @ 0..256 => Some(Symbol::Byte(byte as u8)),
-            256 => Some(Symbol::Eof),
-            257 => Some(Symbol::Esc),
-            _ => None,
-        }
-    }
-}
-
-impl Display for Symbol {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Symbol::Byte(b) => write!(f, "{}", b),
-            Symbol::Eof => write!(f, "EOF"),
-            Symbol::Esc => write!(f, "ESCAPE"),
-        }
-    }
-}
 
 /// A struct describing the Cumulative Frequency Interval of a symbol
 #[derive(Debug, Clone)]

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -15,12 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
+use crate::number_types::{ConstrainedNum, FREQUENCY_BITS};
 
-mod bit_buffer;
-mod frequencies;
-mod number_types;
-
-fn main() {
-    println!("Hello, world!");
-}
+/// Number type for all frequencies, used to limit a frequency's bits
+pub type Frequency = ConstrainedNum<FREQUENCY_BITS>;

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+pub mod mutable_table;
 pub mod static_table;
 mod symbol;
 #[cfg(test)]

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -16,6 +16,60 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 use crate::number_types::{ConstrainedNum, FREQUENCY_BITS};
+use std::fmt::{Display, Formatter};
 
 /// Number type for all frequencies, used to limit a frequency's bits
 pub type Frequency = ConstrainedNum<FREQUENCY_BITS>;
+
+/// The number of unique symbols (256 byte values + 1 EOF + 1 ESCAPE)
+pub const UNIQUE_SYMBOLS_AMOUNT: usize = 258;
+
+/// A symbol in the compression/decompression process, its possible values contain all byte values
+/// plus additional metadata values
+#[derive(Copy, Clone, Debug)]
+pub enum Symbol {
+    /// A byte value
+    Byte(u8),
+    /// An End-Of-File value
+    Eof,
+    /// An 'escape' value
+    Esc,
+}
+
+impl Symbol {
+    pub fn is_escape(&self) -> bool {
+        matches!(self, Symbol::Esc)
+    }
+
+    /// Maps a symbol to an index. It is guaranteed that if two symbols are not the same, they will
+    /// never receive the same index, and that the returned index is within the interval
+    /// `[0, UNIQUE_SYMBOLS_AMOUNT)`.
+    pub const fn to_index(&self) -> usize {
+        match self {
+            Symbol::Byte(byte) => *byte as usize,
+            Symbol::Eof => 256,
+            Symbol::Esc => 257,
+        }
+    }
+
+    /// Constructs the original symbol from its assigned index. If the given index isn't mapped to
+    /// any symbol, None is returned.
+    pub const fn from_index(index: usize) -> Option<Self> {
+        match index {
+            byte @ 0..256 => Some(Symbol::Byte(byte as u8)),
+            256 => Some(Symbol::Eof),
+            257 => Some(Symbol::Esc),
+            _ => None,
+        }
+    }
+}
+
+impl Display for Symbol {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Symbol::Byte(b) => write!(f, "{}", b),
+            Symbol::Eof => write!(f, "EOF"),
+            Symbol::Esc => write!(f, "ESCAPE"),
+        }
+    }
+}

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -73,3 +73,11 @@ impl Display for Symbol {
         }
     }
 }
+
+/// A struct describing the Cumulative Frequency Interval of a symbol
+#[derive(Debug, Clone)]
+pub struct Cfi {
+    pub start: Frequency,
+    pub end: Frequency,
+    pub total: Frequency,
+}

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -17,6 +17,8 @@
 
 pub mod static_table;
 mod symbol;
+#[cfg(test)]
+mod unit_tests;
 
 use crate::number_types::{ConstrainedNum, FREQUENCY_BITS};
 
@@ -24,7 +26,7 @@ use crate::number_types::{ConstrainedNum, FREQUENCY_BITS};
 pub type Frequency = ConstrainedNum<FREQUENCY_BITS>;
 
 /// A struct describing the Cumulative Frequency Interval of a symbol
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Cfi {
     pub start: Frequency,
     pub end: Frequency,

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -17,6 +17,7 @@
 
 mod symbol;
 
+pub use self::symbol::Symbol;
 use crate::number_types::{ConstrainedNum, FREQUENCY_BITS};
 
 /// Number type for all frequencies, used to limit a frequency's bits
@@ -28,4 +29,17 @@ pub struct Cfi {
     pub start: Frequency,
     pub end: Frequency,
     pub total: Frequency,
+}
+
+/// The necessary functions any frequency table must implement
+pub trait FrequencyTable {
+    /// Returns the CFI assigned to the given symbol, or None if such CFI is empty (start == end).
+    fn get_cfi(&self, symbol: &Symbol) -> Option<Cfi>;
+
+    /// Given a cumulative frequency value, return the symbol whose CFI contains the value.
+    /// If such CFI is not found, None is returned.
+    fn get_symbol(&self, cumulative_frequency: Frequency) -> Option<Symbol>;
+
+    /// Returns the total number of frequencies saved in the table.
+    fn get_total(&self) -> Frequency;
 }

--- a/src/frequencies/mod.rs
+++ b/src/frequencies/mod.rs
@@ -44,7 +44,7 @@ impl Symbol {
     /// Maps a symbol to an index. It is guaranteed that if two symbols are not the same, they will
     /// never receive the same index, and that the returned index is within the interval
     /// `[0, UNIQUE_SYMBOLS_AMOUNT)`.
-    pub const fn to_index(&self) -> usize {
+    pub const fn get_index(&self) -> usize {
         match self {
             Symbol::Byte(byte) => *byte as usize,
             Symbol::Eof => 256,

--- a/src/frequencies/mutable_table/fenwick.rs
+++ b/src/frequencies/mutable_table/fenwick.rs
@@ -63,9 +63,21 @@ impl FenwickTree {
     }
 }
 
+impl<const N: usize> From<&[CalculationsType; N]> for FenwickTree {
+    fn from(values: &[CalculationsType; N]) -> Self {
+        FenwickTree::from(&values[..])
+    }
+}
+
+impl From<&Vec<CalculationsType>> for FenwickTree {
+    fn from(values: &Vec<CalculationsType>) -> Self {
+        FenwickTree::from(&values[..])
+    }
+}
+
 impl From<&[CalculationsType]> for FenwickTree {
     /// Constructs a FenwickTree containing the given values.
-    /// 
+    ///
     /// This function is more efficient than adding them manually to an empty tree, as this function
     /// optimizes the operation and reduces the time complexity from **O(n log n)** to **O(n)**.
     fn from(values: &[CalculationsType]) -> Self {
@@ -84,6 +96,85 @@ impl From<&[CalculationsType]> for FenwickTree {
             }
         }
 
-        Self { data: data.into_boxed_slice() }
+        Self {
+            data: data.into_boxed_slice(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_fenwick_tree() {
+        let values = [1, 2, 3, 4, 5];
+        let tree = FenwickTree::from(&values[..]);
+
+        // Test if the cumulative sums are correct:
+        assert_eq!(tree.get_sum(0), 0); // Sum up to index 0 (should be 0)
+        assert_eq!(tree.get_sum(1), 1); // Sum up to index 1 (should be 1)
+        assert_eq!(tree.get_sum(2), 3); // Sum up to index 2 (should be 1 + 2)
+        assert_eq!(tree.get_sum(3), 6); // Sum up to index 3 (should be 1 + 2 + 3)
+        assert_eq!(tree.get_sum(4), 10); // Sum up to index 4 (should be 1 + 2 + 3 + 4)
+        assert_eq!(tree.get_sum(5), 15); // Sum up to index 5 (should be 1 + 2 + 3 + 4 + 5)
+    }
+
+    #[test]
+    fn test_empty_tree() {
+        let tree = FenwickTree::new(5);
+
+        // For an empty tree, all sums should be zero
+        assert_eq!(tree.get_sum(0), 0);
+        assert_eq!(tree.get_sum(1), 0);
+        assert_eq!(tree.get_sum(2), 0);
+        assert_eq!(tree.get_sum(3), 0);
+        assert_eq!(tree.get_sum(4), 0);
+        assert_eq!(tree.get_sum(5), 0);
+    }
+
+    #[test]
+    fn test_add() {
+        let mut tree = FenwickTree::from(&[1, 2, 3, 4, 5]);
+
+        // New tree after addition - [1, 2, 6, 4, 5]:
+        tree.add(2, 3);
+
+        assert_eq!(tree.get_sum(1), 1); // 1
+        assert_eq!(tree.get_sum(2), 3); // 1 + 2 = 3
+        assert_eq!(tree.get_sum(3), 9); // 1 + 2 + 6 = 9
+        assert_eq!(tree.get_sum(4), 13); // 1 + 2 + 6 + 4 = 13
+        assert_eq!(tree.get_sum(5), 18); // 1 + 2 + 6 + 4 + 5 = 18
+    }
+
+    #[test]
+    fn test_multiple_adds() {
+        let mut tree = FenwickTree::from(&[1, 2, 3, 4, 5]);
+
+        // New tree after both additions = [1, 7, 3, 14, 5]
+        tree.add(3, 10);
+        tree.add(1, 5);
+
+        assert_eq!(tree.get_sum(1), 1); // 1
+        assert_eq!(tree.get_sum(2), 8); // 1 + 7 = 8
+        assert_eq!(tree.get_sum(3), 11); // 1 + 7 + 3 = 11
+        assert_eq!(tree.get_sum(4), 25); // 1 + 7 + 3 + 14 = 25
+        assert_eq!(tree.get_sum(5), 30); // 1 + 7 + 3 + 14 + 5 = 30
+    }
+
+    #[test]
+    fn test_edge_case_empty_values() {
+        let empty: Vec<CalculationsType> = Vec::new();
+        let tree = FenwickTree::from(&empty); // Create an empty tree
+        assert_eq!(tree.get_sum(0), 0); // There should be no sum for any index
+    }
+
+    #[test]
+    fn test_large_input() {
+        let values: Vec<CalculationsType> = (1..=10000).collect();
+        let tree = FenwickTree::from(&values);
+
+        // Test if the sum of the first 10000 values is correct
+        assert_eq!(tree.get_sum(10_000), 50005000); // Sum of first 10000 natural numbers: n*(n+1)/2
     }
 }

--- a/src/frequencies/mutable_table/fenwick.rs
+++ b/src/frequencies/mutable_table/fenwick.rs
@@ -51,6 +51,11 @@ impl FenwickTree {
         }
         sum
     }
+    
+    /// Returns the length of the tree, i.e: how many elements it contains
+    pub fn len(&self) -> usize {
+        self.data.len() - 1
+    }
 
     /// Adds a certain amount to an index in the tree in **O(log n)** time complexity.
     pub fn add(&mut self, mut index: usize, amount: CalculationsType) {

--- a/src/frequencies/mutable_table/fenwick.rs
+++ b/src/frequencies/mutable_table/fenwick.rs
@@ -51,4 +51,14 @@ impl FenwickTree {
         }
         sum
     }
+
+    /// Adds a certain amount to an index in the tree in **O(log n)** time complexity.
+    pub fn add(&mut self, mut index: usize, amount: CalculationsType) {
+        // Shift the index by one since the fenwick tree is 1-based:
+        index += 1;
+        while index < self.data.len() {
+            self.data[index] += amount;
+            index += lsb(index);
+        }
+    }
 }

--- a/src/frequencies/mutable_table/fenwick.rs
+++ b/src/frequencies/mutable_table/fenwick.rs
@@ -51,7 +51,7 @@ impl FenwickTree {
         }
         sum
     }
-    
+
     /// Returns the length of the tree, i.e: how many elements it contains
     pub fn len(&self) -> usize {
         self.data.len() - 1

--- a/src/frequencies/mutable_table/fenwick.rs
+++ b/src/frequencies/mutable_table/fenwick.rs
@@ -14,3 +14,30 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use crate::number_types::CalculationsType;
+
+/// Computes the least significant set bit of a number
+fn lsb(n: usize) -> usize {
+    let n = n as isize;
+    (n & -n) as usize
+}
+
+/// A data structure that allows efficient calculation of cumulative summation AND mutation of
+/// values
+pub struct FenwickTree {
+    // Values of the tree, allow for quick computation of cumulative sum AND mutation of values.
+    // It uses Box since we never append/remove elements, only mutate them:
+    data: Box<[CalculationsType]>,
+}
+
+impl FenwickTree {
+    /// Creates a new, empty FenwickTree with the given size
+    pub fn new(size: usize) -> Self {
+        // Fenwick trees index calculations depend on the indices starting at 1, so add an extra
+        // element to ensure this:
+        Self {
+            data: vec![0; size + 1].into_boxed_slice()
+        }
+    }
+}

--- a/src/frequencies/mutable_table/fenwick.rs
+++ b/src/frequencies/mutable_table/fenwick.rs
@@ -37,7 +37,18 @@ impl FenwickTree {
         // Fenwick trees index calculations depend on the indices starting at 1, so add an extra
         // element to ensure this:
         Self {
-            data: vec![0; size + 1].into_boxed_slice()
+            data: vec![0; size + 1].into_boxed_slice(),
         }
+    }
+
+    /// Computes the cumulative sum of all values up to (but not including) the given index.<br>
+    /// This function's time complexity is **O(log n)**.
+    pub fn get_sum(&self, mut index: usize) -> CalculationsType {
+        let mut sum = 0;
+        while 0 < index && index < self.data.len() {
+            sum += self.data[index];
+            index -= lsb(index);
+        }
+        sum
     }
 }

--- a/src/frequencies/mutable_table/fenwick.rs
+++ b/src/frequencies/mutable_table/fenwick.rs
@@ -1,0 +1,16 @@
+// PPM-CLI: A Command-Line Interface for compressing data using Arithmetic Coding + Prediction by
+// Partial Matching
+// Copyright (C) 2025  Yair Ziv
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/frequencies/mutable_table/fenwick.rs
+++ b/src/frequencies/mutable_table/fenwick.rs
@@ -62,3 +62,28 @@ impl FenwickTree {
         }
     }
 }
+
+impl From<&[CalculationsType]> for FenwickTree {
+    /// Constructs a FenwickTree containing the given values.
+    /// 
+    /// This function is more efficient than adding them manually to an empty tree, as this function
+    /// optimizes the operation and reduces the time complexity from **O(n log n)** to **O(n)**.
+    fn from(values: &[CalculationsType]) -> Self {
+        // Initialize data to be all zeroes. Fenwick trees are 1-based, so we add 1 to the length:
+        let mut data = vec![0; values.len() + 1];
+
+        for i in 1..data.len() {
+            // Copy from values:
+            data[i] += values[i - 1];
+
+            // Find the parent index, and add to it as well:
+            let parent_idx = i + lsb(i);
+            if parent_idx < data.len() {
+                let add_to_parent = data[i];
+                data[parent_idx] += add_to_parent;
+            }
+        }
+
+        Self { data: data.into_boxed_slice() }
+    }
+}

--- a/src/frequencies/mutable_table/mod.rs
+++ b/src/frequencies/mutable_table/mod.rs
@@ -1,0 +1,17 @@
+// PPM-CLI: A Command-Line Interface for compressing data using Arithmetic Coding + Prediction by
+// Partial Matching
+// Copyright (C) 2025  Yair Ziv
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+mod fenwick;

--- a/src/frequencies/mutable_table/mod.rs
+++ b/src/frequencies/mutable_table/mod.rs
@@ -77,10 +77,31 @@ impl FrequencyTable for MutableFrequencyTable {
     }
 
     fn get_index(&self, cumulative_frequency: Frequency) -> Option<usize> {
-        todo!()
+        // Implement binary search (get_sum doesn't include the index so only decrement 1 from len):
+        let (mut left, mut right) = (0, self.fenwick.len() - 1);
+        let cumulative_frequency = *cumulative_frequency;
+
+        while left <= right {
+            let middle = (left + right) >> 1;
+
+            // Check lower bound:
+            if cumulative_frequency < self.fenwick.get_sum(middle) {
+                right = middle - 1;
+            }
+            // Check upper bound:
+            else if cumulative_frequency >= self.fenwick.get_sum(middle + 1) {
+                left = middle + 1;
+            }
+            // Spot on!
+            else {
+                return Some(middle);
+            }
+        }
+
+        None
     }
 
     fn get_total(&self) -> Frequency {
-        todo!()
+        self.total
     }
 }

--- a/src/frequencies/mutable_table/mod.rs
+++ b/src/frequencies/mutable_table/mod.rs
@@ -58,6 +58,18 @@ impl MutableFrequencyTable {
             total: accum,
         })
     }
+    
+    /// Adds a certain amount to the frequency at the given index in the table.
+    /// 
+    /// If the result of that addition exceeds the bits allowed for a frequency, it is not saved in
+    /// the table.
+    pub fn add_frequency(&mut self, index: usize, amount: Frequency) {
+        // Since `total` is the largest, if adding to it fails adding to anything else will too:
+        if let Ok(new_total) = Frequency::new(*self.total + *amount) {
+            self.total = new_total;
+            self.fenwick.add(index, *amount);
+        }
+    }
 }
 
 impl FrequencyTable for MutableFrequencyTable {

--- a/src/frequencies/mutable_table/mod.rs
+++ b/src/frequencies/mutable_table/mod.rs
@@ -49,10 +49,7 @@ impl MutableFrequencyTable {
         let total = Frequency::new(fenwick.get_sum(fenwick.len()))
             .context("Failed to create mutable table, overflow occurred for total")?;
 
-        Ok(Self {
-            fenwick,
-            total,
-        })
+        Ok(Self { fenwick, total })
     }
 
     /// Adds a certain amount to the frequency at the given index in the table.
@@ -70,7 +67,7 @@ impl MutableFrequencyTable {
 
 impl FrequencyTable for MutableFrequencyTable {
     fn get_cfi(&self, index: usize) -> Option<Cfi> {
-        if index < self.fenwick.len() - 1 {
+        if index < self.fenwick.len() {
             Some(Cfi {
                 // Invariants ensure unwrapping frequencies is safe:
                 start: Frequency::new(self.fenwick.get_sum(index))

--- a/src/frequencies/mutable_table/mod.rs
+++ b/src/frequencies/mutable_table/mod.rs
@@ -58,9 +58,9 @@ impl MutableFrequencyTable {
             total: accum,
         })
     }
-    
+
     /// Adds a certain amount to the frequency at the given index in the table.
-    /// 
+    ///
     /// If the result of that addition exceeds the bits allowed for a frequency, it is not saved in
     /// the table.
     pub fn add_frequency(&mut self, index: usize, amount: Frequency) {

--- a/src/frequencies/mutable_table/mod.rs
+++ b/src/frequencies/mutable_table/mod.rs
@@ -1,3 +1,6 @@
+use crate::frequencies::mutable_table::fenwick::FenwickTree;
+use crate::frequencies::Frequency;
+
 // PPM-CLI: A Command-Line Interface for compressing data using Arithmetic Coding + Prediction by
 // Partial Matching
 // Copyright (C) 2025  Yair Ziv
@@ -15,3 +18,42 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 mod fenwick;
+
+use anyhow::{Context, Result};
+
+/// A frequency table which can be mutated
+pub struct MutableFrequencyTable {
+    /// The frequencies, stored in a fenwick tree for efficient querying and mutating (O(log n))
+    fenwick: FenwickTree,
+
+    /// The total cumulative frequency. It can be computed from the fenwick tree, but saving it is
+    /// easy and makes its query more efficient
+    total: Frequency,
+}
+
+impl MutableFrequencyTable {
+    /// Creates a mutable frequency table from the frequencies provided here.<br>
+    /// The new table's length will be the length of the provided slice.
+    ///
+    /// The frequencies provided here should not be cumulative, and the function will fail if at
+    /// any point the sum of the slice's frequencies exceeds the allowed bits.
+    pub fn new(frequencies: &[Frequency]) -> Result<Self> {
+        let mut accum = Frequency::zero();
+        let mut current_idx = 1; // Keep first index 0
+        let mut fenwick = FenwickTree::new(frequencies.len() + 1);
+
+        for frequency in frequencies.iter() {
+            accum = Frequency::new(*accum + **frequency).context(format!(
+                "Failed to create mutable table, index {} caused an overflow", current_idx - 1
+            ))?;
+            
+            fenwick.add(current_idx, *accum);
+            current_idx += 1;
+        }
+
+        Ok(Self {
+            fenwick,
+            total: accum,
+        })
+    }
+}

--- a/src/frequencies/static_table.rs
+++ b/src/frequencies/static_table.rs
@@ -67,9 +67,9 @@ impl FrequencyTable for StaticFrequencyTable {
     fn get_index(&self, cumulative_frequency: Frequency) -> Option<usize> {
         // Use binary search since all frequencies are non-negative and therefor all cumulative
         // frequencies are sorted:
-        let (mut left, mut right) = (0, self.cum_freqs.len() - 1);
+        let (mut left, mut right) = (0, self.cum_freqs.len() - 2);
 
-        while left < right {
+        while left <= right {
             let middle = (left + right) >> 1;
 
             // Check lower bound:

--- a/src/frequencies/static_table.rs
+++ b/src/frequencies/static_table.rs
@@ -64,14 +64,14 @@ impl FrequencyTable for StaticFrequencyTable {
             })
     }
 
-    fn get_symbol(&self, cumulative_frequency: Frequency) -> Option<usize> {
-        // Use binary search since all frequencies are non-negative and therefor all cumulative 
+    fn get_index(&self, cumulative_frequency: Frequency) -> Option<usize> {
+        // Use binary search since all frequencies are non-negative and therefor all cumulative
         // frequencies are sorted:
         let (mut left, mut right) = (0, self.cum_freqs.len() - 1);
 
         while left < right {
             let middle = (left + right) >> 1;
-            
+
             // Check lower bound:
             if cumulative_frequency < self.cum_freqs[middle] {
                 right = middle - 1;
@@ -85,7 +85,7 @@ impl FrequencyTable for StaticFrequencyTable {
                 return Some(middle);
             }
         }
-        
+
         None
     }
 

--- a/src/frequencies/static_table.rs
+++ b/src/frequencies/static_table.rs
@@ -1,0 +1,24 @@
+// PPM-CLI: A Command-Line Interface for compressing data using Arithmetic Coding + Prediction by
+// Partial Matching
+// Copyright (C) 2025  Yair Ziv
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::Frequency;
+
+/// A frequency table whose values cannot be updated after initialization
+pub struct StaticFrequencyTable {
+    /// The cumulative frequencies, stored in a box for memory optimization reasons
+    cum_freqs: Box<[Frequency]>,
+}

--- a/src/frequencies/symbol.rs
+++ b/src/frequencies/symbol.rs
@@ -1,0 +1,71 @@
+// PPM-CLI: A Command-Line Interface for compressing data using Arithmetic Coding + Prediction by
+// Partial Matching
+// Copyright (C) 2025  Yair Ziv
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use std::fmt::{Display, Formatter};
+
+/// The number of unique symbols (256 byte values + 1 EOF + 1 ESCAPE)
+pub const UNIQUE_SYMBOLS_AMOUNT: usize = 258;
+
+/// A symbol in the compression/decompression process, its possible values contain all byte values
+/// plus additional metadata values
+#[derive(Copy, Clone, Debug)]
+pub enum Symbol {
+    /// A byte value
+    Byte(u8),
+    /// An End-Of-File value
+    Eof,
+    /// An 'escape' value
+    Esc,
+}
+
+impl Symbol {
+    pub fn is_escape(&self) -> bool {
+        matches!(self, Symbol::Esc)
+    }
+
+    /// Maps a symbol to an index. It is guaranteed that if two symbols are not the same, they will
+    /// never receive the same index, and that the returned index is within the interval
+    /// `[0, UNIQUE_SYMBOLS_AMOUNT)`.
+    pub const fn get_index(&self) -> usize {
+        match self {
+            Symbol::Byte(byte) => *byte as usize,
+            Symbol::Eof => 256,
+            Symbol::Esc => 257,
+        }
+    }
+
+    /// Constructs the original symbol from its assigned index. If the given index isn't mapped to
+    /// any symbol, None is returned.
+    pub const fn from_index(index: usize) -> Option<Self> {
+        match index {
+            byte @ 0..256 => Some(Symbol::Byte(byte as u8)),
+            256 => Some(Symbol::Eof),
+            257 => Some(Symbol::Esc),
+            _ => None,
+        }
+    }
+}
+
+impl Display for Symbol {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Symbol::Byte(b) => write!(f, "{}", b),
+            Symbol::Eof => write!(f, "EOF"),
+            Symbol::Esc => write!(f, "ESCAPE"),
+        }
+    }
+}

--- a/src/frequencies/unit_tests.rs
+++ b/src/frequencies/unit_tests.rs
@@ -17,6 +17,7 @@
 
 use super::static_table::StaticFrequencyTable;
 use super::{Cfi, Frequency, FrequencyTable};
+use crate::frequencies::mutable_table::MutableFrequencyTable;
 
 #[test]
 fn test_static_frequency_table_creation() {
@@ -81,4 +82,75 @@ fn test_static_frequency_table_overflow() {
     let max = Frequency::max();
     let result = StaticFrequencyTable::new(&[max, Frequency::one()]);
     assert!(result.is_err());
+}
+
+#[test]
+fn test_creation_and_get_cfi() {
+    let freqs = vec![1, 2, 3]
+        .into_iter()
+        .map(Frequency::new)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let table = MutableFrequencyTable::new(&freqs).unwrap();
+
+    let cfi_0 = table.get_cfi(0).unwrap();
+    assert_eq!(*cfi_0.start, 0);
+    assert_eq!(*cfi_0.end, 1);
+
+    let cfi_1 = table.get_cfi(1).unwrap();
+    assert_eq!(*cfi_1.start, 1);
+    assert_eq!(*cfi_1.end, 3);
+
+    let cfi_2 = table.get_cfi(2).unwrap();
+    assert_eq!(*cfi_2.start, 3);
+    assert_eq!(*cfi_2.end, 6);
+
+    assert!(table.get_cfi(3).is_none());
+
+    assert_eq!(*table.get_total(), 6);
+}
+
+#[test]
+fn test_get_index() {
+    let freqs = vec![1, 2, 3]
+        .into_iter()
+        .map(Frequency::new)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let table = MutableFrequencyTable::new(&freqs).unwrap();
+
+    assert_eq!(table.get_index(Frequency::new(0).unwrap()), Some(0));
+    assert_eq!(table.get_index(Frequency::new(1).unwrap()), Some(1));
+    assert_eq!(table.get_index(Frequency::new(2).unwrap()), Some(1));
+    assert_eq!(table.get_index(Frequency::new(3).unwrap()), Some(2));
+    assert_eq!(table.get_index(Frequency::new(5).unwrap()), Some(2));
+    assert_eq!(table.get_index(Frequency::new(6).unwrap()), None); // Out of range
+}
+
+#[test]
+fn test_add_frequency() {
+    let freqs = vec![1, 1, 1]
+        .into_iter()
+        .map(Frequency::new)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+
+    let mut table = MutableFrequencyTable::new(&freqs).unwrap();
+
+    // Before update
+    let cfi_1 = table.get_cfi(1).unwrap();
+    assert_eq!(*cfi_1.start, 1);
+    assert_eq!(*cfi_1.end, 2);
+
+    // Add frequency
+    table.add_frequency(1, Frequency::new(3).unwrap());
+
+    // After update
+    let cfi_1 = table.get_cfi(1).unwrap();
+    assert_eq!(*cfi_1.start, 1);
+    assert_eq!(*cfi_1.end, 5);
+
+    assert_eq!(*table.get_total(), 7);
 }

--- a/src/frequencies/unit_tests.rs
+++ b/src/frequencies/unit_tests.rs
@@ -1,0 +1,84 @@
+// PPM-CLI: A Command-Line Interface for compressing data using Arithmetic Coding + Prediction by
+// Partial Matching
+// Copyright (C) 2025  Yair Ziv
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+use super::static_table::StaticFrequencyTable;
+use super::{Cfi, Frequency, FrequencyTable};
+
+#[test]
+fn test_static_frequency_table_creation() {
+    let freqs = vec![
+        Frequency::new(2).unwrap(),
+        Frequency::new(3).unwrap(),
+        Frequency::new(5).unwrap(),
+    ];
+    let table = StaticFrequencyTable::new(&freqs).unwrap();
+
+    assert_eq!(table.get_total(), Frequency::new(10).unwrap());
+
+    // Cumulative frequencies: [0, 2, 5, 10]
+    assert_eq!(
+        table.get_cfi(0),
+        Some(Cfi {
+            start: Frequency::new(0).unwrap(),
+            end: Frequency::new(2).unwrap(),
+            total: Frequency::new(10).unwrap()
+        })
+    );
+    assert_eq!(
+        table.get_cfi(1),
+        Some(Cfi {
+            start: Frequency::new(2).unwrap(),
+            end: Frequency::new(5).unwrap(),
+            total: Frequency::new(10).unwrap()
+        })
+    );
+    assert_eq!(
+        table.get_cfi(2),
+        Some(Cfi {
+            start: Frequency::new(5).unwrap(),
+            end: Frequency::new(10).unwrap(),
+            total: Frequency::new(10).unwrap()
+        })
+    );
+    assert_eq!(table.get_cfi(3), None);
+}
+
+#[test]
+fn test_static_frequency_table_get_index() {
+    let freqs = vec![
+        Frequency::new(1).unwrap(),
+        Frequency::new(2).unwrap(),
+        Frequency::new(3).unwrap(),
+    ];
+    let table = StaticFrequencyTable::new(&freqs).unwrap();
+
+    // Cumulative: [0, 1, 3, 6]
+    assert_eq!(table.get_index(Frequency::new(0).unwrap()), Some(0));
+    assert_eq!(table.get_index(Frequency::new(1).unwrap()), Some(1));
+    assert_eq!(table.get_index(Frequency::new(2).unwrap()), Some(1));
+    assert_eq!(table.get_index(Frequency::new(3).unwrap()), Some(2));
+    assert_eq!(table.get_index(Frequency::new(5).unwrap()), Some(2));
+    assert_eq!(table.get_index(Frequency::new(6).unwrap()), None);
+}
+
+#[test]
+fn test_static_frequency_table_overflow() {
+    // This should fail if it overflows
+    let max = Frequency::max();
+    let result = StaticFrequencyTable::new(&[max, Frequency::one()]);
+    assert!(result.is_err());
+}

--- a/src/frequencies/unit_tests.rs
+++ b/src/frequencies/unit_tests.rs
@@ -152,5 +152,5 @@ fn test_add_frequency() {
     assert_eq!(*cfi_1.start, 1);
     assert_eq!(*cfi_1.end, 5);
 
-    assert_eq!(*table.get_total(), 7);
+    assert_eq!(*table.get_total(), 6);
 }

--- a/src/number_types/mod.rs
+++ b/src/number_types/mod.rs
@@ -16,3 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 mod constraints;
 mod sizes;
+
+// Bring them to scope, spare users from specifying `sizes::` or `constraints::`:
+pub use constraints::*;
+pub use sizes::*;


### PR DESCRIPTION
A module for handling frequencies of symbols for probability model.

## Symbol
An enum that makes it easier to map bytes into indices. May be changed later to allow Binary Arithmetic Coding

## FrequencyTable trait
A trait defining the behavior of a FrequencyTable. It refrains from using Symbols directly to allow different sets of symbols.

## StaticFrequencyTable
An unchanging implementation of FrequencyTable, will probably be used for pre-configured models or equal-distribution models.

## MutableFrequencyTable
A frequency table that can change its frequencies, will be useful for PPM