### PR TITLE
simultaneous-boundaries-update

### DIFF
--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -91,9 +91,7 @@ impl<'a, M: Model> Compressor<'a, M> {
                 }
                 IntervalState::NoConvergence => break Ok(()),
             };
-            self.interval
-                .set_low(low)
-                .and_then(|_| self.interval.set_high(high))?;
+            self.interval.set_boundaries(low, high)?;
         }
     }
 

--- a/src/decompressor.rs
+++ b/src/decompressor.rs
@@ -92,9 +92,7 @@ impl<'a, M: Model, I: Iterator<Item = bool>> Decompressor<'a, M, I> {
 
                 IntervalState::NoConvergence => break Ok(()),
             };
-            self.interval
-                .set_low(low)
-                .and_then(|_| self.interval.set_high(high))?;
+            self.interval.set_boundaries(low, high)?
         }
     }
 

--- a/src/interval/mod.rs
+++ b/src/interval/mod.rs
@@ -81,10 +81,8 @@ impl Interval {
                     )
                 })?;
 
-        // Set boundaries after checking the invariance:
-        Self::validate_boundaries_invariant(&new_low, &new_high)?;
-        self.low = new_low;
-        self.high = new_high;
+        // Set boundaries:
+        self.set_boundaries(new_low, new_high)?;
 
         Ok(())
     }
@@ -113,6 +111,16 @@ impl Interval {
 
     pub fn high(&self) -> IntervalBoundary {
         self.high
+    }
+    
+    pub fn set_boundaries(
+        &mut self,
+        new_low: IntervalBoundary,
+        new_high: IntervalBoundary,
+    ) -> Result<()> {
+        Self::validate_boundaries_invariant(&new_low, &new_high)?;
+        (self.low, self.high) = (new_low, new_high);
+        Ok(())
     }
 
     pub fn set_low(&mut self, new_low: IntervalBoundary) -> Result<()> {

--- a/src/interval/mod.rs
+++ b/src/interval/mod.rs
@@ -112,7 +112,7 @@ impl Interval {
     pub fn high(&self) -> IntervalBoundary {
         self.high
     }
-    
+
     pub fn set_boundaries(
         &mut self,
         new_low: IntervalBoundary,


### PR DESCRIPTION
Fixed bug: When setting interval boundaries one after another, there is a chance an error will be raised even if the new boundaries are valid.
This is because the old boundary could be unfit for the new one, which will cause the invariance to momentarily break