### PR TITLE
infallible-interval-update

### DIFF
--- a/src/compressor.rs
+++ b/src/compressor.rs
@@ -20,7 +20,7 @@ use crate::interval::{Interval, IntervalState};
 use crate::models::{Model, ModelCfi};
 use crate::number_types::INTERVAL_BITS;
 use crate::sim::Symbol;
-use anyhow::{Context, Result};
+use anyhow::Result;
 
 pub struct Compressor<'a, M: Model> {
     /// Number of bits that were put aside in case of near-convergence, their value is unknown until
@@ -108,16 +108,12 @@ impl<'a, M: Model> Compressor<'a, M> {
 
         match cfi {
             ModelCfi::IndexCfi(cfi) => {
-                self.interval
-                    .update(cfi)
-                    .with_context(|| format!("Failed to update interval with symbol {symbol}"))?;
+                self.interval.update(cfi);
                 self.process_interval_state()?;
             }
             // If it's an escape CFI, repeatedly load the symbol:
             ModelCfi::EscapeCfi(cfi) => {
-                self.interval
-                    .update(cfi)
-                    .with_context(|| format!("Failed to update interval with symbol {symbol}"))?;
+                self.interval.update(cfi);
                 self.process_interval_state()?;
                 return self.load_symbol(symbol);
             }

--- a/src/decompressor.rs
+++ b/src/decompressor.rs
@@ -145,7 +145,7 @@ impl<'a, M: Model, I: Iterator<Item = bool>> Decompressor<'a, M, I> {
             ModelCfi::EscapeCfi(cfi) => cfi,
         };
 
-        self.interval.update(cfi)?;
+        self.interval.update(cfi);
         self.process_interval_state()?;
 
         // Return the byte representing the symbol, or None if it's an EOF:

--- a/src/number_types/constraints/mod.rs
+++ b/src/number_types/constraints/mod.rs
@@ -57,6 +57,15 @@ impl<const BITS: u32> ConstrainedNum<BITS> {
         }
     }
 
+    /// Creates a new ConstrainedNum without checking neither the **BITS** nor the number itself.
+    /// <br>
+    /// It is up to the caller of the function to ensure that:
+    /// 1) 0 < **BITS** <= `CalculationsType::BITS`
+    /// 2) `value` uses at most **BITS** bits.
+    pub unsafe fn new_unchecked(value: CalculationsType) -> Self {
+        Self(value)
+    }
+
     /// Creates a ConstrainedNum holding the value 0.<br>
     /// This operation is always safe since 0 uses no bits.
     pub fn zero() -> Self {


### PR DESCRIPTION
Given a basic assumption which is already supported about the CFIs passed into the 'update' function in the Interval struct, that function becomes infallible.
This makes code handling more efficient and readable